### PR TITLE
Remove redundant 'NEW' comment from label

### DIFF
--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -284,7 +284,7 @@ async fn new(...) {
     // ...
     let render_pipeline_layout = device.create_pipeline_layout(
         &wgpu::PipelineLayoutDescriptor {
-            label: Some("Render Pipeline Layout"), // NEW!
+            label: Some("Render Pipeline Layout"),
             bind_group_layouts: &[&texture_bind_group_layout], // NEW!
             push_constant_ranges: &[],
         }


### PR DESCRIPTION
PipelineLayoutDescriptor already has its label set when we get to this point in the tutorial.

(It's set at docs/beginner/tutorial3-pipeline/README.md, line 154)